### PR TITLE
Add suport for unprefixed pointer events

### DIFF
--- a/faketouches.js
+++ b/faketouches.js
@@ -16,7 +16,7 @@
         this.touches = [];
         this.touch_type = FakeTouches.TOUCH_EVENTS;
         this.has_multitouch = true;
-		this.use_prefixed_pointer_event_names = true;
+        this.use_prefixed_pointer_event_names = true;
     }
 
     FakeTouches.POINTER_TOUCH_EVENTS = 100;
@@ -225,7 +225,7 @@
             start: 'pointerdown',
             move: 'pointermove',
             end: 'pointerup'
-		};
+        };
 
         var touchList = this._createTouchList(this.touches);
         touchList.forEach(function(touch) {

--- a/faketouches.js
+++ b/faketouches.js
@@ -16,6 +16,7 @@
         this.touches = [];
         this.touch_type = FakeTouches.TOUCH_EVENTS;
         this.has_multitouch = true;
+		this.use_prefixed_pointer_event_names = true;
     }
 
     FakeTouches.POINTER_TOUCH_EVENTS = 100;
@@ -216,11 +217,15 @@
      */
     function triggerPointerEvents(type, pointerType) {
         var self = this;
-        var names = {
+        var names = self.use_prefixed_pointer_event_names ? {
             start: 'MSPointerDown',
             move: 'MSPointerMove',
             end: 'MSPointerUp'
-        };
+        } : {
+            start: 'pointerdown',
+            move: 'pointermove',
+            end: 'pointerup'
+		};
 
         var touchList = this._createTouchList(this.touches);
         touchList.forEach(function(touch) {

--- a/package.json
+++ b/package.json
@@ -1,26 +1,29 @@
 {
-    "name":"faketouches",
-    "title":"faketouches.js",
-    "description":"Fake touch events for testing",
-    "version":"0.0.4",
-    "licenses": [{
-        "type": "MIT",
-        "url": "https://github.com/jtangelder/faketouches.js/blob/master/LICENSE"
-    }],
-
-    "keywords":["touch","simulate","test"],
-    "author": {
-        "name": "Jorik Tangelder",
-        "email": "j.tangelder@gmail.com"
-    },
-
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/jtangelder/faketouches.js.git"
-    },
-    "bugs": {
-        "url": "https://github.com/jtangelder/faketouches.js/issues"
-    },
-    "devDependencies":{
+  "name": "faketouches",
+  "title": "faketouches.js",
+  "description": "Fake touch events for testing",
+  "version": "0.1.0",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/jtangelder/faketouches.js/blob/master/LICENSE"
     }
+  ],
+  "keywords": [
+    "touch",
+    "simulate",
+    "test"
+  ],
+  "author": {
+    "name": "Jorik Tangelder",
+    "email": "j.tangelder@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jtangelder/faketouches.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jtangelder/faketouches.js/issues"
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
Hi, I noticed that unprefixed pointer events are not supported. This PR adds them, exposed via a configuration flag. It defaults to using prefixed names, so this is just an opt in.
